### PR TITLE
support reading from stdin

### DIFF
--- a/main.go
+++ b/main.go
@@ -536,6 +536,9 @@ func readFile(file string, c *Collection) {
 	key := BenchKey{Config: file}
 
 	text, err := ioutil.ReadFile(file)
+	if err != nil && file == "-" {
+		text, err = ioutil.ReadAll(os.Stdin)
+	}
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
I sometimes found myself wanting to pipe `go test -bench` directly into `benchstat` without detouring through a file. I looked briefly at automatically opening stdin if `nargs < 1` (rather than requiring the `-` be passed), but that looked like it'd require pulling in an `isatty` implementation. 
